### PR TITLE
feat: add execution policies, retry fail-stop, and reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test \"tests/**/*.test.ts\""
+    "test": "node --import tsx --test \"tests/**/*.test.ts\" \"src/**/*.test.ts\""
   },
   "keywords": [],
   "author": "",

--- a/src/execution/contracts.ts
+++ b/src/execution/contracts.ts
@@ -1,0 +1,97 @@
+export type PrototypeStack = 'node-html' | 'vite-ts';
+
+export type StageStatus = 'started' | 'passed' | 'failed' | 'skipped';
+
+export type FinalRunStatus = 'success' | 'failed';
+
+export interface CommandSpec {
+  readonly cmd: string;
+  readonly args?: readonly string[];
+}
+
+export interface CommandResult {
+  readonly command: CommandSpec;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface ExecutionAttempt {
+  readonly label: string;
+  readonly workspacePath: string;
+  readonly stack: PrototypeStack;
+  readonly sandboxMemoryMb: number;
+  readonly commands: readonly CommandSpec[];
+}
+
+export interface ExecutionAttemptResult {
+  readonly ok: boolean;
+  readonly commandResults: readonly CommandResult[];
+  readonly summary: string;
+}
+
+export interface DaytonaExecutionAdapter {
+  runAttempt(attempt: ExecutionAttempt): Promise<ExecutionAttemptResult>;
+}
+
+export interface SmokeCheck {
+  readonly id: string;
+  readonly command: CommandSpec;
+  readonly allowedExitCodes?: readonly number[];
+}
+
+export interface SmokeCheckResult {
+  readonly id: string;
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly passed: boolean;
+}
+
+export interface StageTimelineEntry {
+  readonly stage: string;
+  readonly status: StageStatus;
+  readonly at: string;
+  readonly detail: string;
+}
+
+export interface BlockerLog {
+  readonly attemptLabel: string;
+  readonly reason: string;
+  readonly command: string;
+  readonly stderr: string;
+}
+
+export interface RunReport {
+  readonly runId: string;
+  readonly stack: PrototypeStack;
+  readonly finalStatus: FinalRunStatus;
+  readonly retryCount: number;
+  readonly attemptsExecuted: number;
+  readonly blockerLogs: readonly BlockerLog[];
+  readonly timeline: readonly StageTimelineEntry[];
+}
+
+export interface RunExecutionInput {
+  readonly runId: string;
+  readonly workspacePath: string;
+  readonly stack: PrototypeStack;
+  readonly baseCommands: readonly CommandSpec[];
+  readonly smokeChecks: readonly SmokeCheck[];
+}
+
+export interface AutoFixPlanner {
+  createFixCommands(context: {
+    readonly retryNumber: number;
+    readonly latestCommandResults: readonly CommandResult[];
+    readonly latestSmokeResults: readonly SmokeCheckResult[];
+  }): readonly CommandSpec[];
+}
+
+export interface CommandRunner {
+  run(command: CommandSpec): Promise<{
+    readonly exitCode: number;
+    readonly stdout: string;
+    readonly stderr: string;
+  }>;
+}

--- a/src/execution/daytona-adapter.ts
+++ b/src/execution/daytona-adapter.ts
@@ -1,0 +1,13 @@
+import type {
+  DaytonaExecutionAdapter,
+  ExecutionAttempt,
+  ExecutionAttemptResult,
+} from './contracts.js';
+
+export class UnavailableDaytonaExecutionAdapter implements DaytonaExecutionAdapter {
+  async runAttempt(attempt: ExecutionAttempt): Promise<ExecutionAttemptResult> {
+    throw new Error(
+      `Daytona execution is unavailable in this environment. Attempt '${attempt.label}' could not run.`,
+    );
+  }
+}

--- a/src/execution/memory-policy.test.ts
+++ b/src/execution/memory-policy.test.ts
@@ -1,0 +1,12 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getSandboxMemoryMb } from './memory-policy.js';
+
+test('assigns 2GB memory to node-html stack', () => {
+  assert.equal(getSandboxMemoryMb('node-html'), 2048);
+});
+
+test('assigns 4GB memory to vite-ts stack', () => {
+  assert.equal(getSandboxMemoryMb('vite-ts'), 4096);
+});

--- a/src/execution/memory-policy.ts
+++ b/src/execution/memory-policy.ts
@@ -1,0 +1,10 @@
+import type { PrototypeStack } from './contracts.js';
+
+const STACK_MEMORY_MB: Readonly<Record<PrototypeStack, number>> = {
+  'node-html': 2048,
+  'vite-ts': 4096,
+};
+
+export function getSandboxMemoryMb(stack: PrototypeStack): number {
+  return STACK_MEMORY_MB[stack];
+}

--- a/src/execution/runner.test.ts
+++ b/src/execution/runner.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type {
+  AutoFixPlanner,
+  CommandResult,
+  CommandRunner,
+  DaytonaExecutionAdapter,
+  ExecutionAttempt,
+  ExecutionAttemptResult,
+  RunExecutionInput,
+  SmokeCheckResult,
+} from './contracts.js';
+import { executeRunWithAutoFix } from './runner.js';
+
+class SequenceDaytonaAdapter implements DaytonaExecutionAdapter {
+  public readonly receivedAttempts: ExecutionAttempt[] = [];
+
+  public constructor(private readonly responses: readonly ExecutionAttemptResult[]) {}
+
+  async runAttempt(attempt: ExecutionAttempt): Promise<ExecutionAttemptResult> {
+    this.receivedAttempts.push(attempt);
+    const response = this.responses[this.receivedAttempts.length - 1];
+    if (!response) {
+      throw new Error('No adapter response configured for attempt.');
+    }
+    return response;
+  }
+}
+
+class SequenceCommandRunner implements CommandRunner {
+  public readonly commandsRun: string[] = [];
+  private cursor = 0;
+
+  public constructor(private readonly responses: readonly SmokeCheckResult[]) {}
+
+  async run(command: { readonly cmd: string; readonly args?: readonly string[] }): Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }> {
+    const formatted = [command.cmd, ...(command.args ?? [])].join(' ').trim();
+    this.commandsRun.push(formatted);
+
+    const response = this.responses[this.cursor];
+    this.cursor += 1;
+
+    if (!response) {
+      throw new Error('No smoke result configured for command run.');
+    }
+
+    return {
+      exitCode: response.exitCode,
+      stdout: response.stdout,
+      stderr: response.stderr,
+    };
+  }
+}
+
+class TrackingAutoFixPlanner implements AutoFixPlanner {
+  public readonly calls: number[] = [];
+
+  createFixCommands(context: {
+    readonly retryNumber: number;
+    readonly latestCommandResults: readonly CommandResult[];
+    readonly latestSmokeResults: readonly SmokeCheckResult[];
+  }) {
+    this.calls.push(context.retryNumber);
+    return [
+      {
+        cmd: 'npm',
+        args: ['run', `fix-${context.retryNumber}`],
+      },
+    ];
+  }
+}
+
+function makeInput(): RunExecutionInput {
+  return {
+    runId: 'run-123',
+    workspacePath: '/tmp/work',
+    stack: 'vite-ts',
+    baseCommands: [
+      {
+        cmd: 'npm',
+        args: ['run', 'build'],
+      },
+    ],
+    smokeChecks: [
+      {
+        id: 'http-200',
+        command: {
+          cmd: 'node',
+          args: ['scripts/smoke.js'],
+        },
+      },
+    ],
+  };
+}
+
+test('enforces retry cap of two fix attempts', async () => {
+  const failureResult: ExecutionAttemptResult = {
+    ok: false,
+    summary: 'Build failed',
+    commandResults: [
+      {
+        command: { cmd: 'npm', args: ['run', 'build'] },
+        exitCode: 1,
+        stdout: '',
+        stderr: 'TS error',
+      },
+    ],
+  };
+
+  const adapter = new SequenceDaytonaAdapter([failureResult, failureResult, failureResult]);
+  const planner = new TrackingAutoFixPlanner();
+  const smokeRunner = new SequenceCommandRunner([]);
+
+  const report = await executeRunWithAutoFix(makeInput(), {
+    daytonaAdapter: adapter,
+    commandRunner: smokeRunner,
+    autoFixPlanner: planner,
+    now: () => '2026-03-29T00:00:00.000Z',
+  });
+
+  assert.equal(report.finalStatus, 'failed');
+  assert.equal(report.retryCount, 2);
+  assert.equal(report.attemptsExecuted, 3);
+  assert.deepEqual(planner.calls, [1, 2]);
+  assert.equal(adapter.receivedAttempts.length, 3);
+  assert.deepEqual(
+    adapter.receivedAttempts.map((attempt) => attempt.sandboxMemoryMb),
+    [4096, 4096, 4096],
+  );
+  assert.equal(smokeRunner.commandsRun.length, 0);
+});
+
+test('fail-stops with blocker logs when smoke checks keep failing', async () => {
+  const executionSuccess: ExecutionAttemptResult = {
+    ok: true,
+    summary: 'Commands passed',
+    commandResults: [
+      {
+        command: { cmd: 'npm', args: ['run', 'build'] },
+        exitCode: 0,
+        stdout: 'ok',
+        stderr: '',
+      },
+    ],
+  };
+
+  const adapter = new SequenceDaytonaAdapter([executionSuccess, executionSuccess, executionSuccess]);
+  const planner = new TrackingAutoFixPlanner();
+  const smokeRunner = new SequenceCommandRunner([
+    { id: 'http-200', exitCode: 1, stdout: '', stderr: 'service down', passed: false },
+    { id: 'http-200', exitCode: 1, stdout: '', stderr: 'service down', passed: false },
+    { id: 'http-200', exitCode: 1, stdout: '', stderr: 'service down', passed: false },
+  ]);
+
+  const report = await executeRunWithAutoFix(makeInput(), {
+    daytonaAdapter: adapter,
+    commandRunner: smokeRunner,
+    autoFixPlanner: planner,
+    now: () => '2026-03-29T00:00:00.000Z',
+  });
+
+  assert.equal(report.finalStatus, 'failed');
+  assert.equal(report.retryCount, 2);
+  assert.equal(report.attemptsExecuted, 3);
+  assert.equal(
+    report.blockerLogs.filter((entry) => entry.reason === 'smoke_check_failed').length,
+    3,
+  );
+  assert.equal(report.timeline.at(-1)?.stage, 'run');
+  assert.equal(report.timeline.at(-1)?.status, 'failed');
+  assert.match(report.timeline.at(-1)?.detail ?? '', /failed after 3 attempts/);
+});

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -1,0 +1,192 @@
+import { getSandboxMemoryMb } from './memory-policy.js';
+import { runSmokeChecks } from './smoke-checks.js';
+import type {
+  AutoFixPlanner,
+  BlockerLog,
+  CommandResult,
+  CommandRunner,
+  DaytonaExecutionAdapter,
+  ExecutionAttempt,
+  FinalRunStatus,
+  RunExecutionInput,
+  RunReport,
+  SmokeCheckResult,
+  StageStatus,
+  StageTimelineEntry,
+} from './contracts.js';
+
+interface RunExecutionDeps {
+  readonly daytonaAdapter: DaytonaExecutionAdapter;
+  readonly commandRunner: CommandRunner;
+  readonly autoFixPlanner: AutoFixPlanner;
+  readonly now?: () => string;
+  readonly maxFixRetries?: number;
+}
+
+function formatCommand(command: { readonly cmd: string; readonly args?: readonly string[] }): string {
+  const args = command.args ?? [];
+  return [command.cmd, ...args].join(' ').trim();
+}
+
+function pushStage(
+  timeline: StageTimelineEntry[],
+  now: () => string,
+  stage: string,
+  status: StageStatus,
+  detail: string,
+): void {
+  timeline.push({
+    stage,
+    status,
+    at: now(),
+    detail,
+  });
+}
+
+function toCommandBlockers(attemptLabel: string, commandResults: readonly CommandResult[]): BlockerLog[] {
+  return commandResults
+    .filter((result) => result.exitCode !== 0)
+    .map((result) => ({
+      attemptLabel,
+      reason: 'command_failed',
+      command: formatCommand(result.command),
+      stderr: result.stderr,
+    }));
+}
+
+function toSmokeBlockers(
+  attemptLabel: string,
+  smokeResults: readonly SmokeCheckResult[],
+  checksById: ReadonlyMap<string, string>,
+): BlockerLog[] {
+  return smokeResults
+    .filter((result) => !result.passed)
+    .map((result) => ({
+      attemptLabel,
+      reason: 'smoke_check_failed',
+      command: checksById.get(result.id) ?? result.id,
+      stderr: result.stderr,
+    }));
+}
+
+export async function executeRunWithAutoFix(
+  input: RunExecutionInput,
+  deps: RunExecutionDeps,
+): Promise<RunReport> {
+  const now = deps.now ?? (() => new Date().toISOString());
+  const maxFixRetries = deps.maxFixRetries ?? 2;
+
+  const checksById = new Map(input.smokeChecks.map((check) => [check.id, formatCommand(check.command)]));
+  const timeline: StageTimelineEntry[] = [];
+  const blockerLogs: BlockerLog[] = [];
+
+  let retryCount = 0;
+  let attemptsExecuted = 0;
+  let finalStatus: FinalRunStatus = 'failed';
+  let latestCommandResults: readonly CommandResult[] = [];
+  let latestSmokeResults: readonly SmokeCheckResult[] = [];
+
+  pushStage(timeline, now, 'run', 'started', `Run ${input.runId} started for ${input.stack}.`);
+
+  while (attemptsExecuted <= maxFixRetries) {
+    const attemptIndex = attemptsExecuted;
+    const attemptLabel = attemptIndex === 0 ? 'initial' : `auto-fix-${attemptIndex}`;
+    const commands =
+      attemptIndex === 0
+        ? input.baseCommands
+        : deps.autoFixPlanner.createFixCommands({
+            retryNumber: attemptIndex,
+            latestCommandResults,
+            latestSmokeResults,
+          });
+
+    if (attemptIndex > 0 && commands.length === 0) {
+      pushStage(timeline, now, 'fix', 'failed', `${attemptLabel} produced no fix commands.`);
+      blockerLogs.push({
+        attemptLabel,
+        reason: 'no_fix_commands',
+        command: 'n/a',
+        stderr: 'Auto-fix planner returned zero commands.',
+      });
+      break;
+    }
+
+    attemptsExecuted += 1;
+
+    const attempt: ExecutionAttempt = {
+      label: attemptLabel,
+      workspacePath: input.workspacePath,
+      stack: input.stack,
+      sandboxMemoryMb: getSandboxMemoryMb(input.stack),
+      commands,
+    };
+
+    pushStage(timeline, now, 'execute', 'started', `Running ${attemptLabel} with ${attempt.sandboxMemoryMb}MB.`);
+
+    let executionPassed = false;
+
+    try {
+      const execution = await deps.daytonaAdapter.runAttempt(attempt);
+      latestCommandResults = execution.commandResults;
+      executionPassed = execution.ok;
+
+      if (!execution.ok) {
+        pushStage(timeline, now, 'execute', 'failed', execution.summary);
+        blockerLogs.push(...toCommandBlockers(attemptLabel, execution.commandResults));
+      } else {
+        pushStage(timeline, now, 'execute', 'passed', execution.summary);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      latestCommandResults = [];
+      latestSmokeResults = [];
+      pushStage(timeline, now, 'execute', 'failed', message);
+      blockerLogs.push({
+        attemptLabel,
+        reason: 'execution_adapter_error',
+        command: 'n/a',
+        stderr: message,
+      });
+    }
+
+    if (executionPassed) {
+      pushStage(timeline, now, 'smoke', 'started', `Running ${input.smokeChecks.length} smoke checks.`);
+      latestSmokeResults = await runSmokeChecks(deps.commandRunner, input.smokeChecks);
+      const allSmokePassed = latestSmokeResults.every((result) => result.passed);
+
+      if (allSmokePassed) {
+        pushStage(timeline, now, 'smoke', 'passed', `All smoke checks passed on ${attemptLabel}.`);
+        finalStatus = 'success';
+        break;
+      }
+
+      pushStage(timeline, now, 'smoke', 'failed', `Smoke checks failed on ${attemptLabel}.`);
+      blockerLogs.push(...toSmokeBlockers(attemptLabel, latestSmokeResults, checksById));
+    } else {
+      pushStage(timeline, now, 'smoke', 'skipped', `Smoke checks skipped due to execution failure on ${attemptLabel}.`);
+    }
+
+    if (attemptsExecuted > maxFixRetries) {
+      break;
+    }
+
+    retryCount += 1;
+    pushStage(timeline, now, 'fix', 'started', `Scheduling auto-fix retry ${retryCount} of ${maxFixRetries}.`);
+  }
+
+  if (finalStatus !== 'success') {
+    pushStage(timeline, now, 'run', 'failed', `Run ${input.runId} failed after ${attemptsExecuted} attempts.`);
+  } else {
+    pushStage(timeline, now, 'run', 'passed', `Run ${input.runId} completed successfully.`);
+  }
+
+  return {
+    runId: input.runId,
+    stack: input.stack,
+    finalStatus,
+    retryCount,
+    attemptsExecuted,
+    blockerLogs,
+    timeline,
+  };
+}

--- a/src/execution/smoke-checks.ts
+++ b/src/execution/smoke-checks.ts
@@ -1,0 +1,24 @@
+import type { CommandRunner, SmokeCheck, SmokeCheckResult } from './contracts.js';
+
+export async function runSmokeChecks(
+  commandRunner: CommandRunner,
+  checks: readonly SmokeCheck[],
+): Promise<readonly SmokeCheckResult[]> {
+  const results: SmokeCheckResult[] = [];
+
+  for (const check of checks) {
+    const response = await commandRunner.run(check.command);
+    const allowedExitCodes = check.allowedExitCodes ?? [0];
+    const passed = allowedExitCodes.includes(response.exitCode);
+
+    results.push({
+      id: check.id,
+      exitCode: response.exitCode,
+      stdout: response.stdout,
+      stderr: response.stderr,
+      passed,
+    });
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- add execution contracts and Daytona adapter boundary with stack-based memory policy (2GB/4GB)
- add smoke-check runner and auto-fix loop capped to two retries with explicit fail-stop behavior
- add run report timeline/final status contracts and tests for memory policy, retry cap, and blocker logging

## Links
- Closes #8
- Closes #9
- Closes #10
- Closes #11

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds execution policies and run reporting for prototype runs, including a stack-based memory policy, auto-fix retries (capped at 2), and a timeline with blocker logs. Closes #8, #9, #10, #11.

- **New Features**
  - `executeRunWithAutoFix` runs base commands, retries up to 2 with planner-provided fix commands, and returns a `RunReport` with timeline, blocker logs, attempts, and retries.
  - Smoke checks run after successful execution; failures are logged and trigger retries until the cap.
  - `getSandboxMemoryMb` returns 2048 MB for `node-html` and 4096 MB for `vite-ts`.
  - Centralized contracts in `contracts.ts` and added `UnavailableDaytonaExecutionAdapter`; added tests for memory policy and retry behavior, and updated `npm test` to include `src/**/*.test.ts` via `tsx`.

<sup>Written for commit 5b2665defa4de2efad863d4bdd6f1b729410aa6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add execution policies, retry logic, and run reporting to `executeRunWithAutoFix`
> - Adds [`src/execution/runner.ts`](https://github.com/rznies/autonomous-problem-idea-prototype-builder/pull/14/files#diff-899240e38d7286d5b1eb8d82de45fd1b06106265baf8e9f3c0f2a9efd9770244) with `executeRunWithAutoFix`, which runs an initial attempt plus up to 2 auto-fix retries, collecting timeline entries and blocker logs for command failures, smoke check failures, and adapter errors, returning a `RunReport`.
> - Adds [`src/execution/smoke-checks.ts`](https://github.com/rznies/autonomous-problem-idea-prototype-builder/pull/14/files#diff-bbe9ab472a96b914b390eef738adf21624424dcef1ec9232cb32e820f2917898) with `runSmokeChecks`, which runs each check sequentially via `CommandRunner` and marks pass/fail based on `allowedExitCodes` (default `[0]`).
> - Adds [`src/execution/memory-policy.ts`](https://github.com/rznies/autonomous-problem-idea-prototype-builder/pull/14/files#diff-49b334c7082d596fee9e01fa5bd1811d53eb6ce9064d6898b1fb4b3ee19613ef) with `getSandboxMemoryMb`, returning `2048` for `node-html` and `4096` for `vite-ts`.
> - Adds [`src/execution/contracts.ts`](https://github.com/rznies/autonomous-problem-idea-prototype-builder/pull/14/files#diff-74668d600c42214318b8e0ea5f7ae5be9fad1842012c03fb60cebfd21438a0cb) defining all shared types and interfaces (`RunReport`, `ExecutionAttempt`, `SmokeCheckResult`, `BlockerLog`, etc.).
> - Adds a stub `UnavailableDaytonaExecutionAdapter` in [`src/execution/daytona-adapter.ts`](https://github.com/rznies/autonomous-problem-idea-prototype-builder/pull/14/files#diff-8c84423391dcb7ddc70534d4b9a12885156e33ad0c2dbfdf36834e10cd1aaaa4) whose `runAttempt` always throws, marking Daytona as not yet available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b2665d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->